### PR TITLE
Fix and refactor the DB samples

### DIFF
--- a/PluginExampleProject/src/main/java/com/alpine/plugin/samples/ver1_0/JavaDBTransformer/JavaDBNumericTransformerGUINode.java
+++ b/PluginExampleProject/src/main/java/com/alpine/plugin/samples/ver1_0/JavaDBTransformer/JavaDBNumericTransformerGUINode.java
@@ -46,7 +46,7 @@ public class JavaDBNumericTransformerGUINode extends OperatorGUINode<DBTable, DB
         try {
             //add the parameters
             operatorDialog.addTabularDatasetColumnCheckboxes(
-                    DBTransformerConstants.COLUMNS_TO_TRANSFORM_PARAM,
+                    JavaDBTransformerUtil.COLUMNS_TO_TRANSFORM_PARAM,
                     "Columns to Transform",
                     ColumnFilter.NumericOnly(),
                     SELECTION_GROUP_ID_MAIN,
@@ -55,13 +55,13 @@ public class JavaDBNumericTransformerGUINode extends OperatorGUINode<DBTable, DB
             //the operator dialog methods require scala collection types.
             //use the ScalaConversionUtils class to generate those in Java.
             scala.collection.Seq<String> transformationTypes = JavaConversionUtils.toSeq(Arrays.asList(
-                    DBTransformerConstants.TRANSFORMATION_TYPE_POW2,
-                    DBTransformerConstants.TRANSFORMATION_TYPE_POW3));
+                    JavaDBTransformerUtil.TRANSFORMATION_TYPE_POW2,
+                    JavaDBTransformerUtil.TRANSFORMATION_TYPE_POW3));
             operatorDialog.addDropdownBox(
-                    DBTransformerConstants.TRANSFORMATION_TYPE_PARAM,
+                    JavaDBTransformerUtil.TRANSFORMATION_TYPE_PARAM,
                     "Transformation Type",
                     transformationTypes,
-                    DBTransformerConstants.TRANSFORMATION_TYPE_POW2
+                    JavaDBTransformerUtil.TRANSFORMATION_TYPE_POW2
             );
             DBParameterUtils.addStandardDBOutputParameters(operatorDialog, DBParameterUtils.operatorNameUUIDVariable());
         } catch (Exception e) {
@@ -87,11 +87,11 @@ public class JavaDBNumericTransformerGUINode extends OperatorGUINode<DBTable, DB
 
             if (inputSchema.getDefinedColumns().nonEmpty()) {
                 String[] colsToTransform = params.getTabularDatasetSelectedColumns(
-                        DBTransformerConstants.COLUMNS_TO_TRANSFORM_PARAM)._2();
-                TabularSchema outputSchema = DBTransformerConstants.transformSchema(
+                        JavaDBTransformerUtil.COLUMNS_TO_TRANSFORM_PARAM)._2();
+                TabularSchema outputSchema = JavaDBTransformerUtil.transformSchema(
                         inputSchema,
                         colsToTransform,
-                        params.getStringValue(DBTransformerConstants.TRANSFORMATION_TYPE_PARAM)
+                        params.getStringValue(JavaDBTransformerUtil.TRANSFORMATION_TYPE_PARAM)
                 );
                 operatorSchemaManager.setOutputSchema(outputSchema);
             }

--- a/PluginExampleProject/src/main/java/com/alpine/plugin/samples/ver1_0/JavaDBTransformer/JavaDBTransformerUtil.java
+++ b/PluginExampleProject/src/main/java/com/alpine/plugin/samples/ver1_0/JavaDBTransformer/JavaDBTransformerUtil.java
@@ -24,7 +24,7 @@ import scala.collection.Seq;
 import java.util.ArrayList;
 import java.util.List;
 
-class DBTransformerConstants {
+class JavaDBTransformerUtil {
 
     static final String COLUMNS_TO_TRANSFORM_PARAM = "cols_to_transform";
     static final String TRANSFORMATION_TYPE_PARAM = "transformation_type";
@@ -37,7 +37,7 @@ class DBTransformerConstants {
                                          String transformationType) {
 
         Seq<ColumnDef> inputCols = inputSchema.getDefinedColumns();
-        List<ColumnDef> outputColumnDefs = new ArrayList<ColumnDef>(inputCols.size() + columnsToTransform.length);
+        List<ColumnDef> outputColumnDefs = new ArrayList<>(inputCols.size() + columnsToTransform.length);
 
         for (int i = 0; i < inputCols.length(); i++) {
             outputColumnDefs.add(inputCols.apply(i));
@@ -46,11 +46,15 @@ class DBTransformerConstants {
         for (String columnToTransform : columnsToTransform) {
             outputColumnDefs.add(
                     new ColumnDef(
-                            columnToTransform + "_" + transformationType,
+                            getOutputColumnName(columnToTransform, transformationType),
                             new ColumnType.TypeValue("DOUBLE PRECISION")
                     )
             );
         }
         return TabularSchema.apply(outputColumnDefs);
+    }
+
+    static String getOutputColumnName(String columnToTransform, String transformationType) {
+        return columnToTransform + "_" + transformationType;
     }
 }

--- a/PluginExampleProject/src/main/scala/com/alpine/plugin/samples/ver1_0/DBNumericFeatureTransformer.scala
+++ b/PluginExampleProject/src/main/scala/com/alpine/plugin/samples/ver1_0/DBNumericFeatureTransformer.scala
@@ -166,7 +166,7 @@ class DBNumericFeatureTransformerRuntime extends DBRuntime[DBTable, DBTable] {
           statement.execute(sqlGenerator.getDropTableIfExistsSQL(fullOutputName, cascade = true))
         }
         catch {
-          case (e: Exception) => listener.notifyMessage("A view of the name " + fullOutputName + "exists");
+          case (e: SQLException) =>
         }
         //Now see if there is a view with the output name
         listener.notifyMessage("Dropping view if it exists")

--- a/PluginExampleProject/src/main/scala/com/alpine/plugin/samples/ver1_0/DBNumericFeatureTransformer.scala
+++ b/PluginExampleProject/src/main/scala/com/alpine/plugin/samples/ver1_0/DBNumericFeatureTransformer.scala
@@ -17,6 +17,8 @@
 
 package com.alpine.plugin.samples.ver1_0
 
+import java.sql.SQLException
+
 import com.alpine.plugin.core._
 import com.alpine.plugin.core.datasource.OperatorDataSourceManager
 import com.alpine.plugin.core.db.{DBExecutionContext, DBRuntime}
@@ -24,8 +26,6 @@ import com.alpine.plugin.core.dialog.{ColumnFilter, OperatorDialog}
 import com.alpine.plugin.core.io._
 import com.alpine.plugin.core.io.defaults.DBTableDefault
 import com.alpine.plugin.core.utils.DBParameterUtils
-
-import scala.collection.mutable
 
 /**
   * Ths operator has the same behavior as the Numeric Feature Transformer but works with Database input
@@ -64,7 +64,7 @@ class DBNumericFeatureTransformerGUINode extends OperatorGUINode[
     operatorDialog.addDropdownBox(
       "transformationType",
       "Transformation type",
-      Array("Pow2", "Pow3").toSeq,
+      Seq("Pow2", "Pow3"),
       "Pow2"
     )
 
@@ -117,19 +117,20 @@ object SchemaTransformer {
   def transform(inputSchema: TabularSchema,
                 columnsToTransform: Array[String],
                 transformationType: String): TabularSchema = {
-    val outputColumnDefs = mutable.ArrayBuffer[ColumnDef]()
-    outputColumnDefs ++= inputSchema.getDefinedColumns
-    var i = 0
-    while (i < columnsToTransform.length) {
-      outputColumnDefs +=
+    val outputColumnDefs = inputSchema.getDefinedColumns ++ columnsToTransform.map(
+      columnName => {
         ColumnDef(
-          columnsToTransform(i) + "_" + transformationType.toLowerCase,
+          getOutputColumnName(columnName, transformationType),
           ColumnType.TypeValue("DOUBLE PRECISION")
         )
-      i += 1
-    }
+      }
+    )
 
     TabularSchema(outputColumnDefs)
+  }
+
+  def getOutputColumnName(columnToTransform: String, transformationType: String): String = {
+    columnToTransform + "_" + transformationType
   }
 }
 
@@ -148,74 +149,63 @@ class DBNumericFeatureTransformerRuntime extends DBRuntime[DBTable, DBTable] {
     val isView = DBParameterUtils.getIsViewParam(params)
     val outputName = DBParameterUtils.getResultTableName(params)
     val connectionInfo = context.getDBConnectionInfo
+    val statement = connectionInfo.connection.createStatement()
 
-    //check if there is a table  or with the same name as the output table and drop according to the
-    // "overwrite"
-    val overwrite = DBParameterUtils.getDropIfExistsParameterValue(params)
-    val fullOutputName = getQuotedSchemaTableName(outputSchema, outputName)
-    if (overwrite) {
-      val stmtTable = connectionInfo.connection.createStatement()
-      //First see if a table of that name exists.
-      // This will throw an exception if there is a view with the output name,
-      // we will catch the exception and delete the view in the next block of code.
-      try {
-        listener.notifyMessage("Dropping table if it exists")
-        val dropTableStatementBuilder = new StringBuilder()
-        dropTableStatementBuilder ++= "DROP TABLE IF EXISTS " + fullOutputName + " CASCADE;"
-        stmtTable.execute(dropTableStatementBuilder.toString())
+    try {
+      val sqlGenerator = context.getSQLGenerator
+      //check if there is a table  or with the same name as the output table and drop according to the
+      // "overwrite"
+      val overwrite = DBParameterUtils.getDropIfExistsParameterValue(params)
+      val fullOutputName = sqlGenerator.quoteIdentifier(outputSchema) + "." + sqlGenerator.quoteIdentifier(outputName)
+      if (overwrite) {
+        //First see if a table of that name exists.
+        // This will throw an exception if there is a view with the output name,
+        // we will catch the exception and delete the view in the next block of code.
+        try {
+          listener.notifyMessage("Dropping table if it exists")
+          statement.execute(sqlGenerator.getDropTableIfExistsSQL(fullOutputName, cascade = true))
+        }
+        catch {
+          case (e: Exception) => listener.notifyMessage("A view of the name " + fullOutputName + "exists");
+        }
+        //Now see if there is a view with the output name
+        listener.notifyMessage("Dropping view if it exists")
+        try {
+          statement.execute(sqlGenerator.getDropViewIfExistsSQL(fullOutputName, cascade = true))
+        } catch {
+          case (e: SQLException) =>
+        }
       }
-      catch {
-        case (e: Exception) => listener.notifyMessage("A view of the name " + fullOutputName + "exists");
-      }
-      finally {
-        stmtTable.close()
-      }
-      //Now see if there is a view with the output name
-      listener.notifyMessage("Dropping view if it exists")
-      val dropViewStatementBuilder = new StringBuilder()
-      dropViewStatementBuilder ++= "DROP VIEW IF EXISTS " + fullOutputName + " CASCADE;"
-      val stmtView = connectionInfo.connection.createStatement()
-      stmtView.execute(dropViewStatementBuilder.toString())
-      stmtView.close()
-    }
 
-    val sqlStatementBuilder = new StringBuilder()
-    if (isView) {
-      sqlStatementBuilder ++= "CREATE VIEW " + fullOutputName + " AS ("
-    } else {
-      sqlStatementBuilder ++= "CREATE TABLE " + fullOutputName + " AS ("
-    }
+      val inputSchema = input.tabularSchema
+      val columnDefs = inputSchema.getDefinedColumns
+      val passThroughColumnsSQL = columnDefs.map(
+        columnDef => sqlGenerator.quoteIdentifier(columnDef.columnName)
+      ).mkString(", ")
 
-    val inputSchema = input.tabularSchema
-    val columnDefs = inputSchema.getDefinedColumns
-    sqlStatementBuilder ++= "SELECT "
-    var i = 0
-    while (i < columnDefs.length) {
-      val columnDef = columnDefs(i)
-      sqlStatementBuilder ++= quoteName(columnDef.columnName) + ", "
-      i += 1
-    }
+      val power =
+        if (transformationType.equals("Pow2")) {
+          "2"
+        } else {
+          "3"
+        }
+      val transformedColumnsSQL = columnsToTransform.map(
+        columnToTransform =>
+          "POWER(" + sqlGenerator.quoteIdentifier(columnToTransform) + ", " + power + ") AS " +
+            sqlGenerator.quoteIdentifier(SchemaTransformer.getOutputColumnName(columnToTransform, transformationType))
+      ).mkString(", ")
 
-    val power =
-      if (transformationType.equals("Pow2")) {
-        "2"
-      } else {
-        "3"
-      }
-    i = 0
-    while (i < columnsToTransform.length) {
-      val columnToTransform = columnsToTransform(i)
-      sqlStatementBuilder ++= "POWER(" + quoteName(columnToTransform) + ", " + power + ") AS "
-      sqlStatementBuilder ++= columnToTransform + "_pow" + power
-      i += 1
-      if (i != columnsToTransform.length) {
-        sqlStatementBuilder ++= ", "
-      }
+      val createOutputSQL = sqlGenerator.getCreateTableOrViewAsSelectSQL(
+        columns = passThroughColumnsSQL + ", " + transformedColumnsSQL,
+        sourceTable = sqlGenerator.quoteIdentifier(input.schemaName) + "." + sqlGenerator.quoteIdentifier(input.tableName),
+        destinationTable = fullOutputName,
+        isView = isView
+      )
+
+      statement.execute(createOutputSQL)
+    } finally {
+      statement.close()
     }
-    sqlStatementBuilder ++= " FROM " + getQuotedSchemaTableName(input.schemaName, input.tableName) + ");"
-    val stmt = connectionInfo.connection.createStatement()
-    stmt.execute(sqlStatementBuilder.toString())
-    stmt.close()
 
     //create the output schema
     val outputTabularSchema =
@@ -232,18 +222,9 @@ class DBNumericFeatureTransformerRuntime extends DBRuntime[DBTable, DBTable] {
       isView,
       connectionInfo.name,
       connectionInfo.url,
-      Some(params.operatorInfo),
       //save keys to the output to create visualizations
       Map("TestValue1" -> new Integer(1), "TestValue2" -> new Integer(2))
     )
-  }
-
-  def getQuotedSchemaTableName(schemaName: String, tableName: String): String = {
-    quoteName(schemaName) + "." + quoteName(tableName)
-  }
-
-  def quoteName(colName: String): String = {
-    "\"" + colName + "\""
   }
 
 }


### PR DESCRIPTION
The Java DB sample was failing due to inconsistent casing - the columns in the metadata had capitals, but the columns in the table were all lower case. I updated this so it consistently uses the transformation type, which is cased, and so the column name is quoted in the SQL to preserve the case.

Also updated the Scala sample to use the same casing, to use the SQLGenerator, and to be more scala style.

@rachelwarren @pauljchang @mthyen review?