### PR TITLE
documentation around windows and the linear regression test

### DIFF
--- a/PluginExampleProject/src/test/scala/com/alpine/plugin/samples/ver1_0/LinearRegressionTrainingJobTest.scala
+++ b/PluginExampleProject/src/test/scala/com/alpine/plugin/samples/ver1_0/LinearRegressionTrainingJobTest.scala
@@ -18,8 +18,23 @@ import org.scalatest.junit.JUnitRunner
  * Note: If you examine the results of the regression evaluator for the linear regression
  * model on this data you will notice that this algorithm does a very poor job on
  * data which isn't normalized.
+  *
+  *
+  * Warning: This test may not run on windows without some extra configuration step.
+  * See: http://nishutayaltech.blogspot.com/2015/04/how-to-run-apache-spark-on-windows7-in.html
+  * *
+  * The linear regression model in MLLib (unlike the other spark operators in this project)
+  * uses some Hadoop functionality to save intermediate results. Running hadoop on windows
+  * requires that local hadoop and the hadoop home variable correctly configured and winutils
+  * executable to be downloaded and present on your machine. .
+  * You may run into this problem if using Spark CORE or the hive context to run local tests in
+  * particularly to read and save in a windows environment. See SPARK-2356.
+
+  * To run this test either
+  * a) Run in a windows VM
+  * b) Follow the instructions described above to correctly configure the windows system.
  */
-@RunWith(classOf[JUnitRunner])
+
 class LinearRegressionTrainingJobTest extends SimpleAbstractSparkJobSuite {
   import TestSparkContexts._
   //values which we can use in both tests

--- a/PluginExampleProject/src/test/scala/com/alpine/plugin/samples/ver1_0/LinearRegressionTrainingJobTest.scala
+++ b/PluginExampleProject/src/test/scala/com/alpine/plugin/samples/ver1_0/LinearRegressionTrainingJobTest.scala
@@ -26,12 +26,12 @@ import org.scalatest.junit.JUnitRunner
   * The linear regression model in MLLib (unlike the other spark operators in this project)
   * uses some Hadoop functionality to save intermediate results. Running hadoop on windows
   * requires that local hadoop and the hadoop home variable correctly configured and winutils
-  * executable to be downloaded and present on your machine. .
+  * executable to be downloaded and present on your machine.
   * You may run into this problem if using Spark CORE or the hive context to run local tests in
   * particularly to read and save in a windows environment. See SPARK-2356.
 
   * To run this test either
-  * a) Run in a windows VM
+  * a) Run in a Linux VM
   * b) Follow the instructions described above to correctly configure the windows system.
  */
 


### PR DESCRIPTION
@jthompson6 @nelsonam 
What I have done is disable the linear regression test so that it won't run automatically in the build. Users can manually run it from inteli-j or by adding the @runwith annotation themselves. I have also added a comment explaining the problem. I think they will run into this issue writing tests that a) use the hive context or b) use any of Spark/Hadoop functionality (the problem here) linear regression is saving some intermediate results). I have attached links to some resources that can help them configure their systems in that case. 